### PR TITLE
Reuse accessibility identifier to get XCUIElement

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - UITestHelper (0.3.0):
-    - UITestHelper/Core (= 0.3.0)
-  - UITestHelper/App (0.3.0)
-  - UITestHelper/Core (0.3.0)
+  - UITestHelper (1.3.1):
+    - UITestHelper/Core (= 1.3.1)
+  - UITestHelper/App (1.3.1)
+  - UITestHelper/Core (1.3.1)
 
 DEPENDENCIES:
   - UITestHelper (from `./`)
@@ -10,11 +10,11 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   UITestHelper:
-    :path: ./
+    :path: "./"
 
 SPEC CHECKSUMS:
-  UITestHelper: 57e1d4608eaaf73c11f10aad5928f4ee8679ef8f
+  UITestHelper: 947d402afa2e77bcdec4c2b11b9f61a6f52fecaf
 
 PODFILE CHECKSUM: e269804d43724355c0d938a0f0d4e5c0f7f75276
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.5.2

--- a/Source/RawRepresentable+XCUIElement.swift
+++ b/Source/RawRepresentable+XCUIElement.swift
@@ -1,0 +1,51 @@
+//
+//  RawRepresentable+XCUIElement.swift
+//  Pods-UITestHelperApp
+//
+//  Created by Maljaars, Samuel on 29/05/2018.
+//
+
+import XCTest
+
+/*
+ This extension enables retrieving an XCUIElement from a string enum value that has also been used as accessibility identifier.
+
+ Example usage:
+
+ // Example enum shared between app development target and app UI testing target (Page Object Pattern).
+ // This enum needs to be shared between the main development and UI testing target.
+ enum Login: String {
+    case userNameField
+    case passwordField
+    case submitButton
+ }
+
+ // Use of enum in your app source code:
+ userNameField.accessibilityIdentifier = Login.userNameField.rawValue
+ passwordField.accessibilityIdentifier = Login.passwordField.rawValue
+ submitButton.accessibilityIdentifier = Login.submitButton.rawValue
+
+ // Use of enum in your UI test code:
+ Login.userNameField.tap()
+ Login.passwordField.tap()
+ Login.submitButton.tap()
+ XCTAssertTrue(Login.submitButton.exists)
+
+ */
+public extension RawRepresentable {
+
+    var element: XCUIElement {
+        if let identifier = self.rawValue as? String {
+            return elementForIdentifier(identifier).firstMatch
+        }
+        fatalError("Couldn't cast rawValue \(self.rawValue) to String")
+    }
+
+    var exists: Bool {
+        return element.exists
+    }
+
+    func tap() {
+        element.tap()
+    }
+}

--- a/UITestHelper.podspec
+++ b/UITestHelper.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "UITestHelper"
-  s.version      = "1.3.1"
+  s.version      = "1.4.0"
   s.summary      = "UI test helper functions"
 
   s.description  = <<-EOS

--- a/UITestHelper.xcodeproj/project.pbxproj
+++ b/UITestHelper.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		04BD278C20BDA7E000BCE56B /* AccessibilityIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BD278B20BDA7E000BCE56B /* AccessibilityIdentifier.swift */; };
+		04BD278D20BDA83400BCE56B /* AccessibilityIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BD278B20BDA7E000BCE56B /* AccessibilityIdentifier.swift */; };
 		45680A7A2E292E74D3037503 /* Pods_UITestHelperApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A465357AD139CC65FFC2A7F6 /* Pods_UITestHelperApp.framework */; };
 		7F75C5281E4536EA003B08C5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F75C5271E4536EA003B08C5 /* AppDelegate.swift */; };
 		7F75C52A1E4536EA003B08C5 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F75C5291E4536EA003B08C5 /* ViewController.swift */; };
@@ -30,6 +32,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		04BD278B20BDA7E000BCE56B /* AccessibilityIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityIdentifier.swift; sourceTree = "<group>"; };
 		13D5E72F75F79FB57BF6E1D1 /* Pods-UITestHelperApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UITestHelperApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UITestHelperApp/Pods-UITestHelperApp.debug.xcconfig"; sourceTree = "<group>"; };
 		18BB0B8A63042C713FBAEA73 /* Pods-UITestHelperUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UITestHelperUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UITestHelperUITests/Pods-UITestHelperUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		38FFA42FA9C58CD307C6A96B /* Pods_UITestHelper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UITestHelper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -101,6 +104,7 @@
 				7F75C52E1E4536EA003B08C5 /* Assets.xcassets */,
 				7F75C5301E4536EA003B08C5 /* LaunchScreen.storyboard */,
 				7F75C5331E4536EA003B08C5 /* Info.plist */,
+				04BD278B20BDA7E000BCE56B /* AccessibilityIdentifier.swift */,
 			);
 			name = UITestHelperApp;
 			path = UITestHelper;
@@ -151,7 +155,6 @@
 				7F75C5211E4536EA003B08C5 /* Frameworks */,
 				7F75C5221E4536EA003B08C5 /* Resources */,
 				4A410DAFB4591356F1430B13 /* [CP] Embed Pods Frameworks */,
-				ACF9FD65C9F2DB56E12F7BC4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -171,7 +174,6 @@
 				7F75C5351E4536EA003B08C5 /* Frameworks */,
 				7F75C5361E4536EA003B08C5 /* Resources */,
 				4EA955B5E3279F9C25089689 /* [CP] Embed Pods Frameworks */,
-				8B0DA0B6A97D7F77CC3003C1 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -302,36 +304,6 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-UITestHelperUITests/Pods-UITestHelperUITests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		8B0DA0B6A97D7F77CC3003C1 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-UITestHelperUITests/Pods-UITestHelperUITests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		ACF9FD65C9F2DB56E12F7BC4 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-UITestHelperApp/Pods-UITestHelperApp-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		F152681F3D1B4799EA5EAE04 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -360,6 +332,7 @@
 				7F75C52A1E4536EA003B08C5 /* ViewController.swift in Sources */,
 				7F75C5281E4536EA003B08C5 /* AppDelegate.swift in Sources */,
 				7F75C5491E4544D9003B08C5 /* LaunchArguments.swift in Sources */,
+				04BD278C20BDA7E000BCE56B /* AccessibilityIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -368,6 +341,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7F75C53D1E4536EA003B08C5 /* UITestHelperUITests.swift in Sources */,
+				04BD278D20BDA83400BCE56B /* AccessibilityIdentifier.swift in Sources */,
 				7F75C5481E4543A2003B08C5 /* LaunchArguments.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/UITestHelper/AccessibilityIdentifier.swift
+++ b/UITestHelper/AccessibilityIdentifier.swift
@@ -1,0 +1,18 @@
+//
+//  AccessibilityIdentifier.swift
+//  UITestHelperApp
+//
+//  Created by Maljaars, Samuel on 29/05/2018.
+//  Copyright © 2018 evict. All rights reserved.
+//
+
+import Foundation
+
+//Enum is added to both UITestHelperApp and UITestHelperUITests targets
+enum AccessibilityIdentifier {
+
+    enum HomeScreen: String {
+        case showButton
+        case hideButton
+    }
+}

--- a/UITestHelper/Base.lproj/Main.storyboard
+++ b/UITestHelper/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -107,6 +107,7 @@
                     </view>
                     <connections>
                         <outlet property="hideButton" destination="sos-2W-5bQ" id="fV6-dV-nJM"/>
+                        <outlet property="showButton" destination="dsd-GY-ubC" id="m9e-0h-xHD"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/UITestHelper/ViewController.swift
+++ b/UITestHelper/ViewController.swift
@@ -12,7 +12,8 @@ import UITestHelper
 class ViewController: UIViewController {
 
     @IBOutlet weak var hideButton: UIButton!
-    
+    @IBOutlet weak var showButton: UIButton!
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -23,6 +24,9 @@ class ViewController: UIViewController {
         if isLaunchedWith("NoneEnumOption") {
             
         }
+
+        hideButton.accessibilityIdentifier = AccessibilityIdentifier.HomeScreen.hideButton.rawValue
+        showButton.accessibilityIdentifier = AccessibilityIdentifier.HomeScreen.showButton.rawValue
     }
 
     @IBAction func showButtonTouchUpInside(_ sender: Any) {

--- a/UITestHelperUITests/UITestHelperUITests.swift
+++ b/UITestHelperUITests/UITestHelperUITests.swift
@@ -9,6 +9,8 @@
 import XCTest
 import UITestHelper
 
+typealias HomeScreen = AccessibilityIdentifier.HomeScreen
+
 class UITestHelperUITests: XCTestCase {
         
     override func setUp() {
@@ -69,5 +71,10 @@ class UITestHelperUITests: XCTestCase {
         app.switches.element(boundBy: 0).setSwitch(true)
         app.switches.element(boundBy: 0).setSwitch(false)
         app.switches.element(boundBy: 1).setSwitch(true)
+    }
+
+    func testEnumWithIdentifiersReusedForInteractingWithXCUIElement() {
+        HomeScreen.showButton.tap()
+        HomeScreen.hideButton.tap()
     }
 }


### PR DESCRIPTION
added an extension to RawRepresentable in order to reuse accessibility identifiers defined in a String enum to get the corresponding XCUIElement.

Updated the Example project with a UITest showing how to use this way of writing a UITest.
Bumped version in podspec to 1.4.0